### PR TITLE
🧹 [code health] Remove unused `numpy` and `title` imports in `home.py`

### DIFF
--- a/finaltest2/apps/home.py
+++ b/finaltest2/apps/home.py
@@ -1,8 +1,6 @@
 #importing necessary libraries
 import streamlit as st
 import pandas as pd
-import numpy as np
-from matplotlib.pyplot import title
 import requests
 from bs4 import BeautifulSoup
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports `numpy` and `from matplotlib.pyplot import title` from `finaltest2/apps/home.py`.
💡 **Why:** To improve codebase health, readability, and load times.
✅ **Verification:** Ran `python -m py_compile finaltest2/apps/home.py` to ensure no syntax errors. Also confirmed the imports were not used anywhere else in the file using grep. The code compiles properly. Checked for unwanted `.pyc` tracked files and removed them.
✨ **Result:** Improved readability and maintenance by removing dead code.

---
*PR created automatically by Jules for task [8623831447297889713](https://jules.google.com/task/8623831447297889713) started by @sistaseetaram*