### PR TITLE
🧪 Add unit tests for MultiApp framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/finaltest2/tests/test_multiapp.py
+++ b/finaltest2/tests/test_multiapp.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from finaltest2.multiapp import MultiApp
+
+def test_multiapp_init():
+    app = MultiApp()
+    assert app.apps == []
+
+def test_multiapp_add_app():
+    app = MultiApp()
+    mock_func = MagicMock()
+    app.add_app("Test App", mock_func)
+
+    assert len(app.apps) == 1
+    assert app.apps[0] == {
+        "title": "Test App",
+        "function": mock_func
+    }
+
+@patch("finaltest2.multiapp.st.sidebar")
+def test_multiapp_run(mock_sidebar):
+    app = MultiApp()
+    mock_func = MagicMock()
+    app.add_app("Test App", mock_func)
+
+    # Configure selectbox mock to return our app dictionary
+    mock_sidebar.selectbox.return_value = app.apps[0]
+
+    app.run()
+
+    # Assert sidebar interactions
+    mock_sidebar.image.assert_called_once_with("data/LOGO.png", use_column_width=True)
+    mock_sidebar.write.assert_called_once_with("\n# Dashboard\n ")
+    mock_sidebar.selectbox.assert_called_once()
+
+    # Verify selectbox call arguments
+    args, kwargs = mock_sidebar.selectbox.call_args
+    assert args[0] == "Go To"
+    assert args[1] == app.apps
+
+    # Test the format_func lambda
+    format_func = kwargs['format_func']
+    assert format_func(app.apps[0]) == "Test App"
+
+    # Assert that the selected function was called
+    mock_func.assert_called_once()


### PR DESCRIPTION
🎯 **What:** The `MultiApp` class in `finaltest2/multiapp.py` lacked unit tests. This class manages the multi-page structure of the application.
📊 **Coverage:** 
- Added `test_multiapp_init` to verify initialization to an empty state.
- Added `test_multiapp_add_app` to verify adding applications to the list correctly structures the title and functions mapping.
- Added `test_multiapp_run` to mock Streamlit UI components and verify it correctly calls `selectbox` with the right apps and subsequently calls the function mapped to the selected app.
✨ **Result:** Enhanced test coverage and reliability for core framework logic inside `multiapp.py`. Also added `.gitignore` to prevent committing `__pycache__` and `*.pyc` files.

---
*PR created automatically by Jules for task [7688156780683984283](https://jules.google.com/task/7688156780683984283) started by @sistaseetaram*