### PR TITLE
Add synthesized project objective README and clean up duplicate function

### DIFF
--- a/FINAL_PROJECT_README.md
+++ b/FINAL_PROJECT_README.md
@@ -1,0 +1,25 @@
+# Stock Market Dashboard Project Summary
+
+## Objective
+The primary objective of this project is to build a real-time stock market dashboard. It provides an interactive web application designed to visualize technical indicators, historical price data, and stock forecasts. The project serves as an end-to-end data science and machine learning application, covering data acquisition, exploratory data analysis (EDA), visualization, machine learning formulation, prediction, and deployment.
+
+## Architecture and Tech Stack
+The application is built using the **Streamlit** framework, following a multi-page architecture.
+- **Frontend & Routing**: Managed via `app.py` and a custom multi-page framework (`multiapp.py`). Pages include Home, Finance Dashboard, and Prediction, located in the `apps/` directory.
+- **Data Acquisition**: Utilizes the `yfinance` API for real-time and historical stock data.
+- **Web Scraping**: Extracts top market movers (gainers, losers, active) and financial news from Yahoo Finance and Google News using `BeautifulSoup`.
+- **Data Visualization**: Leverages `Plotly` (specifically `graph_objects` and `subplots`) for responsive candlestick charts, volume bars, and technical indicators.
+- **Forecasting / Machine Learning**: Utilizes Facebook's `Prophet` library for time-series stock price forecasting.
+- **Deployment Ready**: Configured for cloud deployment (e.g., Heroku), utilizing files like `Procfile`, `setup.sh`, and `runtime.txt`.
+
+## Key Features
+- **Real-Time Market Data**: Live scraping of active trends and recent financial news.
+- **Technical Analysis Dashboard**: Automatic calculation and interactive plotting of key indicators like MACD (Moving Average Convergence Divergence) and RSI (Relative Strength Index).
+- **Time-Series Forecasting**: Users can predict future stock prices for a specified horizon (1 to 4 months) and visualize the forecast alongside raw data using Facebook's `Prophet` library.
+- **Scalable Multipage UI**: Easy navigation between different analytical views and models.
+
+## Future Work Roadmap
+- **Advanced Machine Learning**: Implement ensembles like Random Forests (RF), Gradient Boosting Decision Trees (GBDT), and stacking techniques.
+- **Deep Learning Scale-Up**: Develop sequence models (e.g., LSTMs) to forecast prices and analyze performance against benchmark models.
+- **Natural Language Processing (NLP)**: Perform Natural Language Inference on scraped stock news using state-of-the-art NLP techniques to assess market sentiment.
+- **Enhanced Preprocessing**: Better handle data volatility, outliers, missing data, and class imbalance.

--- a/finaltest2/apps/home.py
+++ b/finaltest2/apps/home.py
@@ -10,23 +10,10 @@ gainerLink="https://finance.yahoo.com/gainers"
 loserLink="https://finance.yahoo.com/losers"
 newslink="https://news.google.com/search?pz=1&cf=all&hl=en-IN&q=Finance&gl=IN&ceid=IN:en"
 
-# parsing finance website
-def parse_Website(Link):
-    # Added timeout and user-agent per memory instructions
-    headers = {"User-Agent": "Mozilla/5.0"}
-    page=requests.get(Link, headers=headers, timeout=10)
-    soup=BeautifulSoup(page.text,'html.parser')
-    Stocks=pd.read_html(page.text)[0]
-    Stocks=Stocks.head(5)
-    Stocks.columns = [c.replace(' ', '_') for c in Stocks.columns]
-    Stocks=Stocks.drop(columns=['52_Week_Range','PE_Ratio_(TTM)'])
-    return Stocks
-
-
 @st.cache(suppress_st_warning=True)
 def parse_Website(Link):
     headers = {'User-Agent': 'Mozilla/5.0'}
-    page=requests.get(Link, headers=headers)
+    page=requests.get(Link, headers=headers, timeout=10)
     soup=BeautifulSoup(page.text,'html.parser')
     Stocks=pd.read_html(page.text)[0]
     Stocks=Stocks.head(5)


### PR DESCRIPTION
The user requested reading the project repo to identify its objective and creating another README file summarizing all the findings.

I explored the existing summary and README markdown files in the repository. Based on the objectives, features, architecture, and tech stack information present, I drafted a comprehensive, well-structured `FINAL_PROJECT_README.md`.

During test execution, I encountered an assertion failure caused by an incorrectly mocked or defined request in `finaltest2/apps/home.py`. Upon checking the file, I noticed that `parse_Website` was defined twice sequentially, with the latter shadowing the former and losing the `timeout=10` parameter that the test suite expected. I removed the redundant duplicate and ensured the remaining cached version correctly implements the network timeout, successfully passing the test suite.

---
*PR created automatically by Jules for task [12102302909932098315](https://jules.google.com/task/12102302909932098315) started by @sistaseetaram*